### PR TITLE
Blacklist `propose_block` (mainnet)

### DIFF
--- a/config-example/config.yml
+++ b/config-example/config.yml
@@ -8,6 +8,7 @@ global:
   fork-algorithm: pob                                 # Fork resolution algorithm (fifo, pob, block-time)
   blacklist:                                          # RPC targets to blacklist, can be an entire microservice (i.e. chain), or specific API calls
     - block_store.add_block
+    - chain.propose_block
   # jobs: 32                                          # Number of jobs to run
   # reset: true                                       # DANGEROUS: Resets the entire node. To reset a single microservice, set this in the microservice config
   # whitelist:                                        # RPC targets to whitelist


### PR DESCRIPTION
Resolves #91.

## Brief description
Blacklists `propose_block` API call.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [ ] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
